### PR TITLE
Use standard Promise API

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ browser
         // kills the PhantomJS process
         browser.done();
 
-    }).fail(function (error) {
+    }).catch(function (error) {
         browser.done();
     });
 ```
@@ -116,7 +116,7 @@ browser
 	.then(function (result) {
 		browser.done();
 	})
-	.fail(function (error) {
+	.catch(function (error) {
 		browser.done();
 	});
 ```

--- a/examples/getElement.js
+++ b/examples/getElement.js
@@ -27,6 +27,6 @@ browser
         // kills the PhantomJS process
         browser.done();
 
-    }).fail(function (error) {
+    }).catch(function (error) {
         browser.done();
     });

--- a/lib/Revenant.js
+++ b/lib/Revenant.js
@@ -3,7 +3,7 @@
  */
 
 var async = require('async');
-var Q = require('q');
+var Promise = global.Promise || require('bluebird');
 
 var base = require('./base');
 
@@ -82,20 +82,20 @@ Revenant.prototype = {
     getUrl: function (callback) {
         var self = this;
 
-        var deferred = Q.defer();
-        // if page is available (meaning that the page has been opened or .done() has not been called),
-        // get the current url
-        if (self.page) {
-            self.page.get('url', function (url) {
-                self.__url = url;
-                deferred.resolve(url);
+        return promiseOrCallback(callback, function (resolve) {
+            // if page is available (meaning that the page has been opened or .done() has not been called),
+            // get the current url
+            if (self.page) {
+                self.page.get('url', function (url) {
+                    self.__url = url;
+                    resolve(url);
 
-            });
-        } else {
-            // just get the cached url at the end of every method call
-            deferred.resolve(self.__url);
-        }
-        return deferred.promise.nodeify(callback);
+                });
+            } else {
+                // just get the cached url at the end of every method call
+                resolve(self.__url);
+            }
+        });
     },
 
     /**
@@ -109,23 +109,20 @@ Revenant.prototype = {
     __pushTask: function (task, argument, callback) {
         var self = this;
 
-        var deferred = Q.defer();
-
         var queueArgument = {
             task: task,
             argument: argument
         };
 
-        self.taskQueue.push(queueArgument, function (error, result) {
-            if (error) {
-                deferred.reject(error);
-            } else {
-                deferred.resolve(result);
-            }
+        return promiseOrCallback(callback, function (resolve, reject) {
+            self.taskQueue.push(queueArgument, function (error, result) {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve(result);
+                }
+            });
         });
-
-        return deferred.promise.nodeify(callback);
-
     },
 
     openPage: function (url, callback) {
@@ -203,5 +200,30 @@ Revenant.prototype = {
         }
     }
 };
+
+/**
+ * Build a promise, with an optional node-style callback attached
+ */
+function promiseOrCallback (callback, executor) {
+    var promise = new Promise(executor);
+
+    // no callback: do not attach
+    if (typeof callback !== 'function') {
+        return promise;
+    }
+
+    return promise.then(function (value) {
+        setImmediate(function () {
+            callback(null, value);
+        });
+        return value;
+    }, function (error) {
+        setImmediate(function () {
+            callback(error);
+        });
+        throw error;
+    });
+}
+
 
 module.exports = Revenant;

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "homepage": "https://github.com/skewedlines/Revenant#readme",
   "dependencies": {
     "async": "^1.4.2",
+    "bluebird": "^3.0.5",
     "chance": "^0.7.6",
     "phantom": "^0.8.3",
-    "q": "^1.4.1",
     "sift-string": "0.0.2"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -89,7 +89,7 @@ describe('Testing Revenant Object', function () {
                         done();
                     });
 
-                }).fail(function (error) {
+                }).catch(function (error) {
                     browser.done();
                     done(error);
                 });
@@ -107,7 +107,7 @@ describe('Testing Revenant Object', function () {
                     assert.include(result, '</html>', 'Snapshot results contain closing </html> tag');
                     browser.done();
                     done();
-                }).fail(function (error) {
+                }).catch(function (error) {
                     browser.done();
                     done(error);
                 });
@@ -130,7 +130,7 @@ describe('Testing Revenant Object', function () {
                     assert.isTrue(result.indexOf('BUBBLES') > -1, 'Awaited element innerHTML should contain "BUBBLES"');
                     browser.done();
                     done();
-                }).fail(function (error) {
+                }).catch(function (error) {
                     browser.done();
                     done(error);
                 });
@@ -153,7 +153,7 @@ describe('Testing Revenant Object', function () {
                     assert.isTrue(dom.indexOf(stringQuery) > -1, 'DOM should contain "BUBBLES HI"');
                     browser.done();
                     done();
-                }).fail(function (error) {
+                }).catch(function (error) {
                     browser.done();
                     done(error);
                 });
@@ -182,7 +182,7 @@ describe('Testing Revenant Object', function () {
                     browser.done();
                     done();
                 })
-                .fail(function (error) {
+                .catch(function (error) {
                     browser.done();
                     done(error);
                 });
@@ -211,7 +211,7 @@ describe('Testing Revenant Object', function () {
                     browser.done();
                     done();
                 })
-                .fail(function (error) {
+                .catch(function (error) {
                     browser.done();
                     done(error);
                 });
@@ -237,7 +237,7 @@ describe('Testing Revenant Object', function () {
                     assert.equal(result, USERNAME, 'Username should be equal to filled value');
                     browser.done();
                     done();
-                }).fail(function (error) {
+                }).catch(function (error) {
                     done(error);
                 });
         });
@@ -261,7 +261,7 @@ describe('Testing Revenant Object', function () {
                     assert.ok(result, 'A proper result should be returned, as the ssl error handshake error should have been ignored');
                     browser.done();
                     done();
-                }).fail(function (error) {
+                }).catch(function (error) {
                     browser.done();
                     done(error);
                 });
@@ -285,7 +285,7 @@ describe('Testing Revenant Object', function () {
                     browser.done();
                     done();
                 })
-                .fail(function (error) {
+                .catch(function (error) {
                     browser.done();
                     done(error);
                 });
@@ -309,7 +309,7 @@ describe('Testing Revenant Object', function () {
                     browser.done();
                     done();
                 })
-                .fail(function (error) {
+                .catch(function (error) {
                     browser.done();
                     done(error);
                 });
@@ -337,7 +337,7 @@ describe('Testing Revenant Object', function () {
                     .takeSnapshot()
                     .then(function (result) {
                         done('Error: Result callback should not be called, it is invalid');
-                    }).fail(function (error) {
+                    }).catch(function (error) {
                         browser.done();
                         assert.ok(error, 'Error should say that a page is not open');
                         done();
@@ -359,12 +359,12 @@ describe('Testing Revenant Object', function () {
                 .then(function (result) {
                     browser.done();
                     done('Error callback should have been triggered, not this.');
-                }).fail(function (error) {
+                }).catch(function (error) {
                     browser.done();
                     assert.ok(error, 'Error should say that an invalid url is provided');
                     done();
-                }).fail(function (error) {
-                    // this will be reached if an exception is thrown in the callback for .fail()
+                }).catch(function (error) {
+                    // this will be reached if an exception is thrown in the callback for .catch()
                     // as there are issues when throwing synchronous errors in the final callback
                     done(error);
                 });


### PR DESCRIPTION
I noticed a few flaws about Promise usage that I tried to fix here:

* Using non-standard ``.fail()`` method, which I replaced with standard ``.catch()`` everywhere
* Using non-standard deferred, which I replaced with standard ``Promise`` constructor
* Arguably replaced ``Q`` with ``bluebird`` for performance sake, but only as a fallback if ``global.Promise`` is not found (which means, only for ``node < 0.12``). At this point, as soon as we rely only on standard API, you can use whatever polyfill feels right to you, or even reasonably **drop** support of node ``0.10`` and remove that dependency ;)